### PR TITLE
Remove explicit heading in `contents.md`

### DIFF
--- a/content/docs/Flink SQL Runner/0.2.0/index.adoc
+++ b/content/docs/Flink SQL Runner/0.2.0/index.adoc
@@ -2,9 +2,7 @@
 title = '0.2.0'
 [[cascade]]
     type = 'docs'
-+++
-
-= Flink SQL Runner
++++= Flink SQL Runner
 
 include::overview.adoc[leveloffset=1]
 include::installation.adoc[leveloffset=1]

--- a/content/docs/Flink SQL Runner/_index.md
+++ b/content/docs/Flink SQL Runner/_index.md
@@ -1,5 +1,7 @@
-# Flink SQL Runner Documentation
-
++++
+title = 'Flink SQL Runner Documentation'
+linkTitle = "Flink SQL Runner"
++++
 ## In development documentation
 
 [main](main/index.adoc)

--- a/content/docs/StreamsHub Console/_index.md
+++ b/content/docs/StreamsHub Console/_index.md
@@ -1,5 +1,7 @@
-# StreamsHub Console Documentation
-
++++
+title = 'StreamsHub Console Documentation'
+linkTitle = "StreamsHub Console"
++++
 ## In development documentation
 
 [main](main/index.adoc)

--- a/scripts/templates/contents.md
+++ b/scripts/templates/contents.md
@@ -1,5 +1,7 @@
-# {{ sourceName }} Documentation
-
++++
+title = '{{ sourceName }} Documentation'
+linkTitle = "{{ sourceName }}"
++++
 ## In development documentation
 
 [{{ developmentBranchName }}]({{ developmentBranchIndexFile }})


### PR DESCRIPTION
#12 Generates the titles using the front matter, so `contents.md` should have the title in the front matter.