### PR TITLE
Add parent title before current title

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -5,3 +5,12 @@
 ::placeholder {
     color: var(--gray-500); // Placeholder text is a bit hard to read by default
 }
+
+.subheading {
+    color: var(--gray-500);
+    margin-bottom: 0.5em;
+}
+
+.subheading + h1 {
+    margin-top: 0;
+}

--- a/layouts/_partials/docs/inject/content-before.html
+++ b/layouts/_partials/docs/inject/content-before.html
@@ -1,5 +1,10 @@
-{{ if .Title }}
-<h1>
-  {{ .Title }}
-</h1>
+{{ if and .Parent .Title }}
+<h3 class="subheading">{{ .Parent.LinkTitle }}</h3>
+  <h1>
+    {{ .Title }}
+  </h1>
+{{ else if .Title }}
+  <h1>
+    {{ .Title }}
+  </h1>
 {{ end }}


### PR DESCRIPTION
Fix for [the following comment ](https://github.com/streamshub/streamshub-site/pull/12#pullrequestreview-2958150244) from #12. Possible thanks to #13.

> This is a good improvement.
>
> It would be nice if we could specify a different entry for the nav bar instead of just using the title. It would be good for the page title to be StreamsHub Console 0.8.3 and for the nav bar entry to just be 0.8.3. That might require a tweak to the theme?

![Screenshot From 2025-06-25 16-40-14](https://github.com/user-attachments/assets/3013c47e-6da5-4b54-b4e7-fa15698b1c53)

![image](https://github.com/user-attachments/assets/c238147b-4739-4bed-8142-cf7c1d59137c)
