### PR TITLE
Rebuild site every day at noon

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "0 12 * * *"
+    - cron: "15 4 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The workflow and repository dispatch GitHub API endpoints both require properties in the JSON payload.

You cannot add custom properties to the JSON payload when creating GitHub webhooks.

Therefore, we have to use a cron job for rebuilding the site instead of triggering it on a push to another repository.