### PR TITLE
Improve `publish.yaml`

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,8 +42,10 @@ jobs:
           tar xvf ${{ runner.temp }}/dart-sass.tar.gz --directory=${{ runner.temp }}/
           echo "${{ runner.temp }}/dart-sass" >> $GITHUB_PATH
 
-      - name: Install asciidoctor and ruby-rouge
-        run: sudo apt -y install asciidoctor ruby-rouge
+      - uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: asciidoctor ruby-rouge
+          version: 1.0
 
       - name: Install Java 21
         uses: actions/setup-java@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,28 +34,36 @@ jobs:
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
       - name: Install Dart Sass
         run: sudo snap install dart-sass
+
       - name: Install asciidoctor and ruby-rouge
         run: sudo apt -y install asciidoctor ruby-rouge
+
       - name: Install Java 21
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'
+
       - name: Setup JBang
         uses: jbangdev/setup-jbang@main
+
       - name: Checkout site source
         uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
+
       - name: Update Development Docs
         run: |
           jbang scripts/docBuilder.java ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
+
       - name: Build with Hugo
         env:
           HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
@@ -66,6 +74,7 @@ jobs:
             --gc \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HUGO_VERSION: 0.147.8
+      DART_SASS_VERSION: 1.93.2
     steps:
       - name: Install Hugo CLI
         run: |
@@ -36,7 +37,10 @@ jobs:
           sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
       - name: Install Dart Sass
-        run: sudo snap install dart-sass
+        run: |
+          wget -O ${{ runner.temp }}/dart-sass.tar.gz https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64-musl.tar.gz
+          tar xvf ${{ runner.temp }}/dart-sass.tar.gz --directory=${{ runner.temp }}/
+          echo "${{ runner.temp }}/dart-sass" >> $GITHUB_PATH
 
       - name: Install asciidoctor and ruby-rouge
         run: sudo apt -y install asciidoctor ruby-rouge

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,8 +32,8 @@ jobs:
     steps:
       - name: Install Hugo CLI
         run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb
+          sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
       - name: Install Dart Sass
         run: sudo snap install dart-sass


### PR DESCRIPTION
- Install `dart-sass` from GitHub release instead of snap
- Cache APT packages (APT currently takes up most of the workflow's time)
- Nicer spacing