### PR TITLE
Add the developer quickstart documentation to the site build config

### DIFF
--- a/content/docs/StreamsHub Developer Quick-Start/_index.md
+++ b/content/docs/StreamsHub Developer Quick-Start/_index.md
@@ -1,0 +1,9 @@
++++
+title = 'StreamsHub Developer Quick-Start Documentation'
+linkTitle = "StreamsHub Developer Quick-Start"
++++
+## In development documentation
+
+[main](main/_index.md)
+
+## Released versions documentation

--- a/hugo.toml
+++ b/hugo.toml
@@ -49,21 +49,27 @@ enableGitInfo = true
   weight = 2
 
 [[menu.home]]
+  name = "Developer Quick-Start"
+  pageRef = "/docs/StreamsHub-Developer-Quick-Start/main/"
+  weight = 20
+  parent = "Documentation"
+
+[[menu.home]]
   name = "Console"
   pageRef = "/docs/StreamsHub-Console/"
-  weight = 20
+  weight = 21
   parent = "Documentation"
 
 [[menu.home]]
   name = "Runner"
   pageRef = "/docs/Flink-SQL-Runner/"
-  weight = 21
+  weight = 22
   parent = "Documentation"
 
 [[menu.home]]
   name = "Tutorials"
   pageRef = "/docs/Flink-SQL-Tutorials/main/"
-  weight = 22
+  weight = 23
   parent = "Documentation"
 
 [[menu.home]]

--- a/sources.json
+++ b/sources.json
@@ -1,5 +1,13 @@
 [
     {
+        "name": "StreamsHub Developer Quick-Start",
+        "sourceOwner": "streamshub",
+        "sourceRepository": "developer-quickstart", 
+        "developmentBranch": "main",
+        "docsFolderPath": "docs",
+        "tags":[]
+    },
+    {
         "name": "StreamsHub Console",
         "sourceOwner": "streamshub",
         "sourceRepository": "console", 


### PR DESCRIPTION
Add the documentation for the [developer quick-start](https://github.com/streamshub/developer-quickstart) repository to the site build config. This is setup to only pull the main branch state for each build. If we do a point release we can configure that separately.

This should be merged after [this PR](https://github.com/streamshub/developer-quickstart/pull/14) is merged so that we don't have duplicate titles.